### PR TITLE
Add support for logging and nonblocking modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@ Block certain IP addresses from accessing your Flask application.
 
 Flask-IPBlock is backed by MongoDB and supports application-level caching to boost performance.
 
+Options
+=======
+You can override the default MongoDB read preference via the optional read_preference kwarg.
+
+You can limit the impact of the IP checks on your MongoDB by maintaining a local in-memory LRU cache. To do so, specify its cache_size (i.e. max number of IP addresses it can store) and cache_ttl (i.e. how many seconds each result should be cached for).
+
+To run in dry-run mode without blocking requests, set `blocking_enabled` to `False`. Set `logging_enabled` to `True` to log IPs that match blocking rules -- if enabled, will log even if `blocking_enabled` is False.
+
 Setup
 =====
 
@@ -17,11 +25,6 @@ from flask_ipblock.documents import IPNetwork
 app = Flask(__name__)
 
 # Configuration (e.g. setting up MongoEngine)
-You can override the default MongoDB read preference via the optional read_preference kwarg.
-
-You can limit the impact of the IP checks on your MongoDB by maintaining a local in-memory LRU cache. To do so, specify its cache_size (i.e. max number of IP addresses it can store) and cache_ttl (i.e. how many seconds each result should be cached for).
-
-To run in dry-run mode without blocking requests, set `blocking_enabled` to `False`. Set `logging_enabled` to `True` to log IPs that match blocking rules -- if enabled, will log even if `blocking_enabled` is False.
 
 # Set up IPBlock
 ipblock = IPBlock(app)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ from flask_ipblock.documents import IPNetwork
 app = Flask(__name__)
 
 # Configuration (e.g. setting up MongoEngine)
-# (...)
+You can override the default MongoDB read preference via the optional read_preference kwarg.
+
+You can limit the impact of the IP checks on your MongoDB by maintaining a local in-memory LRU cache. To do so, specify its cache_size (i.e. max number of IP addresses it can store) and cache_ttl (i.e. how many seconds each result should be cached for).
+
+To run in dry-run mode without blocking requests, set `blocking_enabled` to `False`. Set `logging_enabled` to `True` to log IPs that match blocking rules -- if enabled, will log even if `blocking_enabled` is False.
 
 # Set up IPBlock
 ipblock = IPBlock(app)

--- a/flask_ipblock/__init__.py
+++ b/flask_ipblock/__init__.py
@@ -4,8 +4,8 @@ from flask_ipblock.documents import IPNetwork
 
 class IPBlock(object):
 
-    def __init__(self, app, read_preference=None, cache_size=None,
-                 cache_ttl=None):
+    def __init__(self, app, read_preference=None, cache_size=None, cache_ttl=None,
+                 blocking_enabled=True, logging_enabled=False):
         """
         Initialize IPBlock and set up a before_request handler in the
         app.
@@ -18,8 +18,18 @@ class IPBlock(object):
         cache_size (i.e. max number of IP addresses it can store) and
         cache_ttl (i.e. how many seconds each result should be cached
         for).
+
+        To run in dry-run mode without blocking requests, set
+        blocking_enabled to False. Set logging_enabled to True
+        to log IPs that match blocking rules -- if enabled, will
+        log even if blocking_enabled is False.
         """
         self.read_preference = read_preference
+        self.blocking_enabled = blocking_enabled
+        self.logger = None
+        if logging_enabled:
+            self.logger = app.logger
+            self.block_msg = "blocking" if blocking_enabled else "blocking disabled"
 
         if cache_size and cache_ttl:
             # inline import because cachetools dependency is optional.
@@ -59,7 +69,10 @@ class IPBlock(object):
         ip = ip.rsplit(',', 1)[-1].strip()
 
         if self.matches_ip(ip):
-            return 'IP Blocked', 200
+            if self.logger is not None:
+                self.logger.info("IPBlock: matched {0}, {1}".format(ip, self.block_msg))
+            if self.blocking_enabled:
+                return 'IP Blocked', 200
 
     def matches_ip(self, ip):
         """Return True if the given IP is blacklisted, False otherwise."""

--- a/flask_ipblock/__init__.py
+++ b/flask_ipblock/__init__.py
@@ -70,7 +70,7 @@ class IPBlock(object):
 
         if self.matches_ip(ip):
             if self.logger is not None:
-                self.logger.info("IPBlock: matched {0}, {1}".format(ip, self.block_msg))
+                self.logger.info("IPBlock: matched {}, {}".format(ip, self.block_msg))
             if self.blocking_enabled:
                 return 'IP Blocked', 200
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='flask-ipblock',
-    version='0.2',
+    version='0.3',
     url='http://github.com/closeio/flask-ipblock',
     license='MIT',
     description='Block certain IP addresses from accessing your Flask app',


### PR DESCRIPTION
This PR adds two new flags, which by default maintain the current behavior:

- `blocking_enabled`: setting this to `False` allows for using flask-ipblock in a non-enforcing mode. Most helpful when combined with `logging_enabled`
- `logging_enabled`: setting this to `True` will log IP matches at INFO level